### PR TITLE
Address -Wimplicit-function-declaration Warning about kill

### DIFF
--- a/CFInternal.h
+++ b/CFInternal.h
@@ -65,6 +65,7 @@
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_FREEBSD
 #include <sys/time.h>
 #include <pthread.h>
+#include <signal.h>
 #endif
 #include <limits.h>
 #include "auto_stubs.h"


### PR DESCRIPTION
This addresses #15 by adding an `#include` directive for `signal.h`.