### PR TITLE
Address an Issue in Which an Allowably-NULL `cancel` CFRunLoopSourceContext Callout Pointer Causes a Crash

### DIFF
--- a/CFRunLoop.c
+++ b/CFRunLoop.c
@@ -2737,7 +2737,7 @@ void CFRunLoopRemoveSource(CFRunLoopRef rl, CFRunLoopSourceRef rls, CFStringRef 
             }
             __CFRunLoopSourceUnlock(rls);
 	    if (0 == rls->_context.version0.version) {
-	        if (NULL != rls->_context.version0.schedule) {
+	        if (NULL != rls->_context.version0.cancel) {
 	            doVer0Callout = true;
 	        }
 	    }


### PR DESCRIPTION
Backport a fix from CF-855.11 in which an allowably-NULL 'cancel' `CFRunLoopSourceContext` callout results in a segment fault and crash.