### PR TITLE
Address Warning/Error about the Redefinition of `struct timespec` when Compiling against the Project on Linux

### DIFF
--- a/CFPriv.h
+++ b/CFPriv.h
@@ -471,8 +471,8 @@ CF_EXPORT CFMessagePortRef _CFMessagePortCreateLocalEx(CFAllocatorRef allocator,
 
 #endif
 
-#if TARGET_OS_MAC || TARGET_OS_EMBEDDED || TARGET_OS_IPHONE || TARGET_OS_LINUX
-#include <pthread.h>
+#if TARGET_OS_MAC || TARGET_OS_EMBEDDED || TARGET_OS_IPHONE || TARGET_OS_UNIX
+#include <time.h>
 #else
 // Avoid including the pthread header
 #ifndef HAVE_STRUCT_TIMESPEC

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AC_INIT([CoreFoundation],
 # Interface number, revision and age of the library interface passed to
 # libtool when the library is linked.
 #
-AC_SUBST(CF_VERSION_INFO, [635:15:0])
+AC_SUBST(CF_VERSION_INFO, [635:0:15])
 
 #
 # Check the sanity of thes source directory by checking for the


### PR DESCRIPTION
This pull request addresses issue #39 by using `TARGET_OS_UNIX` (the only target conditional defined by TargetConditionals.h) and by specifying the inclusion of time.h rather than pthread.h, the former of which is specified by IEEE Std 1003.1-2001 to define `struct timespec`.