### PR TITLE
Address Warning/Error about the Unknown Type Name of `CFStreamError` when Compiling against the Project on Linux

### DIFF
--- a/CoreFoundation.h
+++ b/CoreFoundation.h
@@ -96,7 +96,7 @@
 #include <CoreFoundation/CFURLAccess.h>
 #include <CoreFoundation/CFUUID.h>
 
-#if (TARGET_OS_MAC && !(TARGET_OS_EMBEDDED || TARGET_OS_IPHONE)) || (TARGET_OS_EMBEDDED || TARGET_OS_IPHONE) || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if (TARGET_OS_MAC && !(TARGET_OS_EMBEDDED || TARGET_OS_IPHONE)) || (TARGET_OS_EMBEDDED || TARGET_OS_IPHONE) || TARGET_OS_WIN32 || TARGET_OS_UNIX
 #include <CoreFoundation/CFBundle.h>
 #include <CoreFoundation/CFMessagePort.h>
 #include <CoreFoundation/CFPlugIn.h>

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AC_INIT([CoreFoundation],
 # Interface number, revision and age of the library interface passed to
 # libtool when the library is linked.
 #
-AC_SUBST(CF_VERSION_INFO, [635:15:0])
+AC_SUBST(CF_VERSION_INFO, [635:0:15])
 
 #
 # Check the sanity of thes source directory by checking for the


### PR DESCRIPTION
This pull request addresses issue #40  by using TARGET_OS_UNIX (the only target conditional defined by TargetConditionals.h) to wrap the inclusion of CFStream.h which defines `CFStreamError`.