### PR TITLE
Address a '-Wimplicit-const-int-float-conversion' Warning for `_CFHashDouble` in _ForFoundationOnly.h_

### DIFF
--- a/ForFoundationOnly.h
+++ b/ForFoundationOnly.h
@@ -496,7 +496,7 @@ CF_INLINE CFHashCode _CFHashDouble(double d) {
     if (d < 0) d = -d;
     dInt = floor(d+0.5);
     CFHashCode integralHash = HASHFACTOR * (CFHashCode)fmod(dInt, (double)ULONG_MAX);
-    return (CFHashCode)(integralHash + (CFHashCode)((d - dInt) * ULONG_MAX));
+    return (CFHashCode)(integralHash + (CFHashCode)((d - dInt) * (double)ULONG_MAX));
 }
 
 


### PR DESCRIPTION
This pull request addresses a '-Wimplicit-const-int-float-conversion' warning for `_CFHashDouble` in _ForFoundationOnly.h_.