### PR TITLE
Address `CFPropertyListCreateWithStream` and `CFPropertyListWrite` Declaration Visibility Issue

### DIFF
--- a/CFPropertyList.h
+++ b/CFPropertyList.h
@@ -42,7 +42,7 @@
 #include <CoreFoundation/CFData.h>
 #include <CoreFoundation/CFString.h>
 #include <CoreFoundation/CFError.h>
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_EMBEDDED || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_EMBEDDED || TARGET_OS_UNIX
 #include <CoreFoundation/CFStream.h>
 #endif
 
@@ -107,7 +107,7 @@ typedef CFIndex CFPropertyListFormat;
 CF_EXPORT
 Boolean CFPropertyListIsValid(CFPropertyListRef plist, CFPropertyListFormat format);
 
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_EMBEDDED || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_EMBEDDED || TARGET_OS_UNIX
 
 /* Writes the bytes of a plist serialization out to the stream.  The
  * stream must be opened and configured -- the function simply writes
@@ -153,7 +153,7 @@ enum {
 CF_EXPORT
 CFPropertyListRef CFPropertyListCreateWithData(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags options, CFPropertyListFormat *format, CFErrorRef *error) CF_AVAILABLE(10_6, 4_0);
 
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_EMBEDDED || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_EMBEDDED || TARGET_OS_UNIX
 
 /* Create and return a property list with a CFReadStream input. TIf the format parameter is non-NULL, it will be set to the format of the data after parsing is complete. The options parameter is used to specify CFPropertyListMutabilityOptions. The streamLength parameter specifies the number of bytes to read from the stream. Set streamLength to 0 to read until the end of the stream is detected. If an error occurs while parsing the data, the return value will be NULL. Additionally, if an error occurs and the error parameter is non-NULL, the error parameter will be set to a CFError describing the problem, which the caller must release. If the parse succeeds, the returned value is a reference to the new property list. It is the responsibility of the caller to release this value.
  */


### PR DESCRIPTION
Address an issue in which `CFPropertyList{CreateWithStream,Write}` are not available when building against the package on Linux since these symbols are guarded by `TARGET_OS_LINUX` rather than `TARGET_OS_UNIX`. The latter is defined as a target conditional in TargetConditionals.h whereas the former is not.