### PR TITLE
Address Fault in CFShow by Not Passing 'NULL' for the Format to fprintf

### DIFF
--- a/CFUtilities.c
+++ b/CFUtilities.c
@@ -552,7 +552,7 @@ static void _CFShowToFile(FILE *file, Boolean flush, const void *obj) {
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
          fprintf_l(file, NULL, "\n");
 #else
-         fprintf(file, NULL, "\n");
+         fprintf(file, "\n");
 #endif
          if (flush) fflush(file);
      }


### PR DESCRIPTION
This addresses #57, by passing "\n" directly to `fprintf` as the message or format string, rather than trying to incorrectly pass `NULL`, followed by "\n". The latter was likely a copy-and-paste error from the related `fprintf_l` line above it.