### PR TITLE
Address Resource Leaks in 'date_test'

### DIFF
--- a/tests/date_test.c
+++ b/tests/date_test.c
@@ -28,6 +28,8 @@ bool check_date_constructors ()
    CFShow(aCFDate);
    
    printf("\n");
+
+   CFRelease(aCFDate);
    
    return true;
 }
@@ -61,6 +63,9 @@ bool check_date_comparison ()
    }
    
    printf("\n");
+
+   CFRelease(date1);
+   CFRelease(date2);
 
    return true;
 }


### PR DESCRIPTION
This addresses #58, by calling `CFRelease` on allocated date resources in `check_date_comparison` and `check_date_constructors`.