### PR TITLE
Optimally Implement __CFActiveProcessorCount When _SC_NPROCESSORS_ONLN is Available

### DIFF
--- a/CFUtilities.c
+++ b/CFUtilities.c
@@ -463,6 +463,8 @@ __private_extern__ CFIndex __CFActiveProcessorCount() {
     if (result != 0) {
         pcnt = 0;
     }
+#elif defined(_SC_NPROCESSORS_ONLN)
+    pcnt = sysconf(_SC_NPROCESSORS_ONLN);
 #else
     // Assume the worst
     pcnt = 1;


### PR DESCRIPTION
Address #80, by using `sysconf(_SC_NPROCESSORS_ONLN)` when `_SC_NPROCESSORS_ONLN` is defined to get the active number of processors on the current system.