### PR TITLE
Address Ineffective Linux Spin Lock Implementation

### DIFF
--- a/CFBundle.c
+++ b/CFBundle.c
@@ -1314,7 +1314,7 @@ static CFBundleRef _CFBundleCreate(CFAllocatorRef allocator, CFURLRef bundleURL,
     bundle->_plugInData._instanceCount = 0;
     bundle->_plugInData._factories = NULL;
 
-    bundle->_bundleLoadingLock = CFSpinLockInit;
+    CF_SPINLOCK_INIT_FOR_STRUCTS(bundle->_bundleLoadingLock);
     
     CFBundleGetInfoDictionary(bundle);
     

--- a/CFRuntime.c
+++ b/CFRuntime.c
@@ -1031,7 +1031,7 @@ void __CFInitialize(void) {
 	for (CFIndex idx = 0; idx < NUM_EXTERN_TABLES; idx++) {
 	    __NSRetainCounters[idx].table = CFBasicHashCreate(kCFAllocatorSystemDefault, kCFBasicHashHasCounts | kCFBasicHashLinearHashing | kCFBasicHashAggressiveGrowth, &CFExternRefCallbacks);
 	    CFBasicHashSetCapacity(__NSRetainCounters[idx].table, 40);
-	    __NSRetainCounters[idx].lock = CFSpinLockInit;
+	    CF_SPINLOCK_INIT_FOR_STRUCTS(__NSRetainCounters[idx].lock);
 	}
 
         /*** _CFRuntimeCreateInstance() can finally be called generally after this line. ***/

--- a/CFSocket.c
+++ b/CFSocket.c
@@ -2322,8 +2322,8 @@ static CFSocketRef _CFSocketCreateWithNative(CFAllocatorRef allocator, CFSocketN
     memory->_f.connected = FALSE;
     memory->_f.writableHint = FALSE;
     memory->_f.closeSignaled = FALSE;
-    memory->_lock = CFSpinLockInit;
-    memory->_writeLock = CFSpinLockInit;
+    CF_SPINLOCK_INIT_FOR_STRUCTS(memory->_lock);
+    CF_SPINLOCK_INIT_FOR_STRUCTS(memory->_writeLock);
     memory->_socket = sock;
     if (INVALID_SOCKET == sock || 0 != getsockopt(sock, SOL_SOCKET, SO_TYPE, (char *)&(memory->_socketType), (socklen_t *)&typeSize)) memory->_socketType = 0;		// cast for WinSock bad API
     memory->_errorCode = 0;

--- a/CFStream.c
+++ b/CFStream.c
@@ -102,7 +102,7 @@ CF_INLINE void checkRLMArray(CFArrayRef arr)
 CF_INLINE void* _CFStreamCreateReserved(CFAllocatorRef alloc) {
 	struct CFStreamAux* aux = (struct CFStreamAux*) CFAllocatorAllocate(alloc, sizeof(struct CFStreamAux), 0);
 	if (aux) {
-		aux->streamLock = CFSpinLockInit;
+		CF_SPINLOCK_INIT_FOR_STRUCTS(aux->streamLock);
         aux->previousRunloopsAndModes = NULL;
 	}
 	return aux;


### PR DESCRIPTION
Address #82, by reverting the currently ineffective Linux and FreeBSD implementation of spin locks to the prior effective `pthread_spinlock_t`-based locks used in opencflite-476.

In addition, use `CF_SPINLOCK_INIT_FOR_STRUCTS`, where required.