### PR TITLE
Address Memory / Resource Leak in BundleExample

### DIFF
--- a/examples/BundleExample/BundleExample.c
+++ b/examples/BundleExample/BundleExample.c
@@ -287,6 +287,10 @@ int main (int argc, const char *argv[]) {
         CFRelease(cfLiteBundlePath);
     }
 
+    if (cfLiteURLRef != 0) {
+        CFRelease(cfLiteURLRef);
+    }
+
     return retval;
 }
 


### PR DESCRIPTION
This addresses #87 by ensuring that `cfLiteURLRef` is released if non-null to prevent a leak or warning when built against `-fsanitize=address` or `-fsanitize=leak`.