### PR TITLE
Address '-Wcpp' Warning/Error for 'sys/sysctl.h' Deprecation on Linux

### DIFF
--- a/CFSocket.c
+++ b/CFSocket.c
@@ -974,7 +974,6 @@ Boolean __CFSocketGetBytesAvailable(CFSocketRef s, CFIndex* ctBytesAvailable) {
 #include <asm/ioctls.h>
 #include <netdb.h>
 #include <netinet/in.h>
-#include <sys/sysctl.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>


### PR DESCRIPTION
This addresses #97 by removing the inclusion of _sys/sysctl.h_ in _CFSocket.c_.