### PR TITLE
Replace CFLog Level Literals with Equivalent Mnemonics

### DIFF
--- a/CFArray.c
+++ b/CFArray.c
@@ -189,7 +189,7 @@ CF_INLINE bool __CFArrayCallBacksMatchCFType(const CFArrayCallBacks *c) {
 }
 
 #if 0
-#define CHECK_FOR_MUTATION(A) do { if ((A)->_mutInProgress) CFLog(3, CFSTR("*** %s: function called while the array (%p) is being mutated in this or another thread"), __PRETTY_FUNCTION__, (A)); } while (0)
+#define CHECK_FOR_MUTATION(A) do { if ((A)->_mutInProgress) CFLog(kCFLogLevelError, CFSTR("*** %s: function called while the array (%p) is being mutated in this or another thread"), __PRETTY_FUNCTION__, (A)); } while (0)
 #define BEGIN_MUTATION(A) do { OSAtomicAdd32Barrier(1, &((struct __CFArray *)(A))->_mutInProgress); } while (0)
 #define END_MUTATION(A) do { OSAtomicAdd32Barrier(-1, &((struct __CFArray *)(A))->_mutInProgress); } while (0)
 #else

--- a/CFBag.c
+++ b/CFBag.c
@@ -807,7 +807,7 @@ void CFBagAddValue(CFMutableHashRef hc, const_any_pointer_t key) {
     __CFGenericValidateType(hc, __kCFBagTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGE(hc, key);
     CFBasicHashAddValue((CFBasicHashRef)hc, (uintptr_t)key, (uintptr_t)value);
@@ -826,7 +826,7 @@ void CFBagReplaceValue(CFMutableHashRef hc, const_any_pointer_t key) {
     __CFGenericValidateType(hc, __kCFBagTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGE(hc, key);
     CFBasicHashReplaceValue((CFBasicHashRef)hc, (uintptr_t)key, (uintptr_t)value);
@@ -845,7 +845,7 @@ void CFBagSetValue(CFMutableHashRef hc, const_any_pointer_t key) {
     __CFGenericValidateType(hc, __kCFBagTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGE(hc, key);
 //#warning this for a dictionary used to not replace the key
@@ -859,7 +859,7 @@ void CFBagRemoveValue(CFMutableHashRef hc, const_any_pointer_t key) {
     __CFGenericValidateType(hc, __kCFBagTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGE(hc, key);
     CFBasicHashRemoveValue((CFBasicHashRef)hc, (uintptr_t)key);
@@ -872,7 +872,7 @@ void CFBagRemoveAllValues(CFMutableHashRef hc) {
     __CFGenericValidateType(hc, __kCFBagTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGEALL(hc);
     CFBasicHashRemoveAllValues((CFBasicHashRef)hc);

--- a/CFDictionary.c
+++ b/CFDictionary.c
@@ -807,7 +807,7 @@ void CFDictionaryAddValue(CFMutableHashRef hc, const_any_pointer_t key) {
     __CFGenericValidateType(hc, __kCFDictionaryTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGE(hc, key);
     CFBasicHashAddValue((CFBasicHashRef)hc, (uintptr_t)key, (uintptr_t)value);
@@ -826,7 +826,7 @@ void CFDictionaryReplaceValue(CFMutableHashRef hc, const_any_pointer_t key) {
     __CFGenericValidateType(hc, __kCFDictionaryTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGE(hc, key);
     CFBasicHashReplaceValue((CFBasicHashRef)hc, (uintptr_t)key, (uintptr_t)value);
@@ -845,7 +845,7 @@ void CFDictionarySetValue(CFMutableHashRef hc, const_any_pointer_t key) {
     __CFGenericValidateType(hc, __kCFDictionaryTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGE(hc, key);
 //#warning this for a dictionary used to not replace the key
@@ -859,7 +859,7 @@ void CFDictionaryRemoveValue(CFMutableHashRef hc, const_any_pointer_t key) {
     __CFGenericValidateType(hc, __kCFDictionaryTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGE(hc, key);
     CFBasicHashRemoveValue((CFBasicHashRef)hc, (uintptr_t)key);
@@ -872,7 +872,7 @@ void CFDictionaryRemoveAllValues(CFMutableHashRef hc) {
     __CFGenericValidateType(hc, __kCFDictionaryTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGEALL(hc);
     CFBasicHashRemoveAllValues((CFBasicHashRef)hc);

--- a/CFInternal.h
+++ b/CFInternal.h
@@ -402,7 +402,7 @@ typedef OSSpinLock CFSpinLock_t;
     OSSpinLock *__lockp__ = (LP); \
     OSSpinLock __lockv__ = *__lockp__; \
     if (0 != __lockv__ && ~0 != __lockv__ && (uintptr_t)__lockp__ != (uintptr_t)__lockv__) { \
-        CFLog(3, CFSTR("In '%s', file %s, line %d, during lock, spin lock %p has value 0x%x, which is neither locked nor unlocked.  The memory has been smashed."), __PRETTY_FUNCTION__, __FILE__, __LINE__, __lockp__, __lockv__); \
+        CFLog(kCFLogLevelError, CFSTR("In '%s', file %s, line %d, during lock, spin lock %p has value 0x%x, which is neither locked nor unlocked.  The memory has been smashed."), __PRETTY_FUNCTION__, __FILE__, __LINE__, __lockp__, __lockv__); \
         /* HALT; */ \
     } \
     OSSpinLockLock(__lockp__); })
@@ -411,7 +411,7 @@ typedef OSSpinLock CFSpinLock_t;
     OSSpinLock *__lockp__ = (LP); \
     OSSpinLock __lockv__ = *__lockp__; \
     if (~0 != __lockv__ && (uintptr_t)__lockp__ != (uintptr_t)__lockv__) { \
-        CFLog(3, CFSTR("In '%s', file %s, line %d, during unlock, spin lock %p has value 0x%x, which is not locked.  The memory has been smashed or the lock is being unlocked when not locked."), __PRETTY_FUNCTION__, __FILE__, __LINE__, __lockp__, __lockv__); \
+        CFLog(kCFLogLevelError, CFSTR("In '%s', file %s, line %d, during unlock, spin lock %p has value 0x%x, which is not locked.  The memory has been smashed or the lock is being unlocked when not locked."), __PRETTY_FUNCTION__, __FILE__, __LINE__, __lockp__, __lockv__); \
         /* HALT; */ \
     } \
     OSSpinLockUnlock(__lockp__); })
@@ -420,7 +420,7 @@ typedef OSSpinLock CFSpinLock_t;
     OSSpinLock *__lockp__ = (LP); \
     OSSpinLock __lockv__ = *__lockp__; \
     if (0 != __lockv__ && ~0 != __lockv__ && (uintptr_t)__lockp__ != (uintptr_t)__lockv__) { \
-        CFLog(3, CFSTR("In '%s', file %s, line %d, during lock, spin lock %p has value 0x%x, which is neither locked nor unlocked.  The memory has been smashed."), __PRETTY_FUNCTION__, __FILE__, __LINE__, __lockp__, __lockv__); \
+        CFLog(kCFLogLevelError, CFSTR("In '%s', file %s, line %d, during lock, spin lock %p has value 0x%x, which is neither locked nor unlocked.  The memory has been smashed."), __PRETTY_FUNCTION__, __FILE__, __LINE__, __lockp__, __lockv__); \
         /* HALT; */ \
     } \
     OSSpinLockTry(__lockp__); })

--- a/CFRunLoop.c
+++ b/CFRunLoop.c
@@ -212,13 +212,13 @@ static void foo() {
 CFOptionFlags responseFlags = 0;
 SInt32 result = CFUserNotificationDisplayAlert(0.0, kCFUserNotificationCautionAlertLevel, NULL, NULL, NULL, CFSTR("High Mach Port Usage"), CFSTR("This application is using a lot of Mach ports."), CFSTR("Default"), CFSTR("Altern"), CFSTR("Other b"), &responseFlags);
 if (0 != result) {
-    CFLog(3, CFSTR("ERROR"));
+    CFLog(kCFLogLevelError, CFSTR("ERROR"));
 } else {
     switch (responseFlags) {
-    case kCFUserNotificationDefaultResponse: CFLog(3, CFSTR("DefaultR")); break;
-    case kCFUserNotificationAlternateResponse: CFLog(3, CFSTR("AltR")); break;
-    case kCFUserNotificationOtherResponse: CFLog(3, CFSTR("OtherR")); break;
-    case kCFUserNotificationCancelResponse: CFLog(3, CFSTR("CancelR")); break;
+    case kCFUserNotificationDefaultResponse: CFLog(kCFLogLevelError, CFSTR("DefaultR")); break;
+    case kCFUserNotificationAlternateResponse: CFLog(kCFLogLevelError, CFSTR("AltR")); break;
+    case kCFUserNotificationOtherResponse: CFLog(kCFLogLevelError, CFSTR("OtherR")); break;
+    case kCFUserNotificationCancelResponse: CFLog(kCFLogLevelError, CFSTR("CancelR")); break;
     }
 }
 
@@ -1312,11 +1312,11 @@ struct __CFRunLoopMode {
 
 CF_INLINE void __CFRunLoopModeLock(CFRunLoopModeRef rlm) {
     pthread_mutex_lock(&(rlm->_lock));
-//    CFLog(6, CFSTR("__CFRunLoopModeLock locked %p"), rlm);
+//    CFLog(kCFLogLevelInfo, CFSTR("__CFRunLoopModeLock locked %p"), rlm);
 }
 
 CF_INLINE void __CFRunLoopModeUnlock(CFRunLoopModeRef rlm) {
-//    CFLog(6, CFSTR("__CFRunLoopModeLock unlocking %p"), rlm);
+//    CFLog(kCFLogLevelInfo, CFSTR("__CFRunLoopModeLock unlocking %p"), rlm);
     pthread_mutex_unlock(&(rlm->_lock));
 }
 
@@ -1453,11 +1453,11 @@ CF_INLINE void __CFRunLoopSetDeallocating(CFRunLoopRef rl) {
 
 CF_INLINE void __CFRunLoopLock(CFRunLoopRef rl) {
     pthread_mutex_lock(&(((CFRunLoopRef)rl)->_lock));
-//    CFLog(6, CFSTR("__CFRunLoopLock locked %p"), rl);
+//    CFLog(kCFLogLevelInfo, CFSTR("__CFRunLoopLock locked %p"), rl);
 }
 
 CF_INLINE void __CFRunLoopUnlock(CFRunLoopRef rl) {
-//    CFLog(6, CFSTR("__CFRunLoopLock unlocking %p"), rl);
+//    CFLog(kCFLogLevelInfo, CFSTR("__CFRunLoopLock unlocking %p"), rl);
     pthread_mutex_unlock(&(((CFRunLoopRef)rl)->_lock));
 }
 
@@ -1710,11 +1710,11 @@ CF_INLINE void __CFRunLoopSourceUnsetSignaled(CFRunLoopSourceRef rls) {
 
 CF_INLINE void __CFRunLoopSourceLock(CFRunLoopSourceRef rls) {
     pthread_mutex_lock(&(rls->_lock));
-//    CFLog(6, CFSTR("__CFRunLoopSourceLock locked %p"), rls);
+//    CFLog(kCFLogLevelInfo, CFSTR("__CFRunLoopSourceLock locked %p"), rls);
 }
 
 CF_INLINE void __CFRunLoopSourceUnlock(CFRunLoopSourceRef rls) {
-//    CFLog(6, CFSTR("__CFRunLoopSourceLock unlocking %p"), rls);
+//    CFLog(kCFLogLevelInfo, CFSTR("__CFRunLoopSourceLock unlocking %p"), rls);
     pthread_mutex_unlock(&(rls->_lock));
 }
 
@@ -1759,11 +1759,11 @@ CF_INLINE void __CFRunLoopObserverUnsetRepeats(CFRunLoopObserverRef rlo) {
 
 CF_INLINE void __CFRunLoopObserverLock(CFRunLoopObserverRef rlo) {
     pthread_mutex_lock(&(rlo->_lock));
-//    CFLog(6, CFSTR("__CFRunLoopObserverLock locked %p"), rlo);
+//    CFLog(kCFLogLevelInfo, CFSTR("__CFRunLoopObserverLock locked %p"), rlo);
 }
 
 CF_INLINE void __CFRunLoopObserverUnlock(CFRunLoopObserverRef rlo) {
-//    CFLog(6, CFSTR("__CFRunLoopObserverLock unlocking %p"), rlo);
+//    CFLog(kCFLogLevelInfo, CFSTR("__CFRunLoopObserverLock unlocking %p"), rlo);
     pthread_mutex_unlock(&(rlo->_lock));
 }
 
@@ -1824,11 +1824,11 @@ CF_INLINE void __CFRunLoopTimerSetDeallocating(CFRunLoopTimerRef rlt) {
 
 CF_INLINE void __CFRunLoopTimerLock(CFRunLoopTimerRef rlt) {
     pthread_mutex_lock(&(rlt->_lock));
-//    CFLog(6, CFSTR("__CFRunLoopTimerLock locked %p"), rlt);
+//    CFLog(kCFLogLevelInfo, CFSTR("__CFRunLoopTimerLock locked %p"), rlt);
 }
 
 CF_INLINE void __CFRunLoopTimerUnlock(CFRunLoopTimerRef rlt) {
-//    CFLog(6, CFSTR("__CFRunLoopTimerLock unlocking %p"), rlt);
+//    CFLog(kCFLogLevelInfo, CFSTR("__CFRunLoopTimerLock unlocking %p"), rlt);
     pthread_mutex_unlock(&(rlt->_lock));
 }
 
@@ -4839,7 +4839,7 @@ static CFStringRef __CFRunLoopTimerCopyDescription(CFTypeRef cf) {	/* DOES CALLO
 }
 
 static void __CFRunLoopTimerDeallocate(CFTypeRef cf) {	/* DOES CALLOUT */
-//CFLog(6, CFSTR("__CFRunLoopTimerDeallocate(%p)"), cf);
+//CFLog(kCFLogLevelInfo, CFSTR("__CFRunLoopTimerDeallocate(%p)"), cf);
     CFRunLoopTimerRef rlt = (CFRunLoopTimerRef)cf;
     __CFRunLoopTimerSetDeallocating(rlt);
     CFRunLoopTimerInvalidate(rlt);	/* DOES CALLOUT */

--- a/CFRuntime.c
+++ b/CFRuntime.c
@@ -586,7 +586,7 @@ void CFRelease(CFTypeRef cf) {
     void **addrs[2] = {&&start, &&end};
     start:;
     if (addrs[0] <= __builtin_return_address(0) && __builtin_return_address(0) <= addrs[1]) {
-	CFLog(3, CFSTR("*** WARNING: Recursion in CFRelease(%p) : %p '%s' : 0x%08lx 0x%08lx 0x%08lx 0x%08lx 0x%08lx 0x%08lx"), cf, object_getClass(cf), object_getClassName(cf), ((uintptr_t *)cf)[0], ((uintptr_t *)cf)[1], ((uintptr_t *)cf)[2], ((uintptr_t *)cf)[3], ((uintptr_t *)cf)[4], ((uintptr_t *)cf)[5]);
+	CFLog(kCFLogLevelError, CFSTR("*** WARNING: Recursion in CFRelease(%p) : %p '%s' : 0x%08lx 0x%08lx 0x%08lx 0x%08lx 0x%08lx 0x%08lx"), cf, object_getClass(cf), object_getClassName(cf), ((uintptr_t *)cf)[0], ((uintptr_t *)cf)[1], ((uintptr_t *)cf)[2], ((uintptr_t *)cf)[3], ((uintptr_t *)cf)[4], ((uintptr_t *)cf)[5]);
 	HALT;
     }
 #endif

--- a/CFSet.c
+++ b/CFSet.c
@@ -807,7 +807,7 @@ void CFSetAddValue(CFMutableHashRef hc, const_any_pointer_t key) {
     __CFGenericValidateType(hc, __kCFSetTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGE(hc, key);
     CFBasicHashAddValue((CFBasicHashRef)hc, (uintptr_t)key, (uintptr_t)value);
@@ -826,7 +826,7 @@ void CFSetReplaceValue(CFMutableHashRef hc, const_any_pointer_t key) {
     __CFGenericValidateType(hc, __kCFSetTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGE(hc, key);
     CFBasicHashReplaceValue((CFBasicHashRef)hc, (uintptr_t)key, (uintptr_t)value);
@@ -845,7 +845,7 @@ void CFSetSetValue(CFMutableHashRef hc, const_any_pointer_t key) {
     __CFGenericValidateType(hc, __kCFSetTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGE(hc, key);
 //#warning this for a dictionary used to not replace the key
@@ -859,7 +859,7 @@ void CFSetRemoveValue(CFMutableHashRef hc, const_any_pointer_t key) {
     __CFGenericValidateType(hc, __kCFSetTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGE(hc, key);
     CFBasicHashRemoveValue((CFBasicHashRef)hc, (uintptr_t)key);
@@ -872,7 +872,7 @@ void CFSetRemoveAllValues(CFMutableHashRef hc) {
     __CFGenericValidateType(hc, __kCFSetTypeID);
     CFAssert2(CFBasicHashIsMutable((CFBasicHashRef)hc), __kCFLogAssertion, "%s(): immutable collection %p passed to mutating operation", __PRETTY_FUNCTION__, hc);
     if (!CFBasicHashIsMutable((CFBasicHashRef)hc)) {
-        CFLog(3, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
+        CFLog(kCFLogLevelError, CFSTR("%s(): immutable collection %p given to mutating function"), __PRETTY_FUNCTION__, hc);
     }
     CF_OBJC_KVO_WILLCHANGEALL(hc);
     CFBasicHashRemoveAllValues((CFBasicHashRef)hc);

--- a/CFUserNotification.c
+++ b/CFUserNotification.c
@@ -68,7 +68,7 @@
 
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_WINDOWS
 
-#define CFUserNotificationLog(alertHeader, alertMessage) CFLog(3, CFSTR("%@:  %@"), alertHeader, alertMessage);
+#define CFUserNotificationLog(alertHeader, alertMessage) CFLog(kCFLogLevelError, CFSTR("%@:  %@"), alertHeader, alertMessage);
 
 enum {
     kCFUserNotificationCancelFlag = (1 << 3),

--- a/examples/CFLocalServer/Client.c
+++ b/examples/CFLocalServer/Client.c
@@ -948,7 +948,7 @@ int main (int argc, const char * argv[])
        err = WSAStartup(versionRequested, &wsaData);
        if (err != 0 || LOBYTE(wsaData.wVersion) != LOBYTE(versionRequested) || HIBYTE(wsaData.wVersion) != HIBYTE(versionRequested)) {
            WSACleanup();
-           CFLog(0, CFSTR("*** Could not initialize WinSock subsystem!!!"));
+           CFLog(kCFLogLevelEmergency, CFSTR("*** Could not initialize WinSock subsystem!!!"));
        }
     }
 #endif

--- a/examples/CFLocalServer/Server.c
+++ b/examples/CFLocalServer/Server.c
@@ -1402,7 +1402,7 @@ int main (int argc, const char * argv[])
        err = WSAStartup(versionRequested, &wsaData);
        if (err != 0 || LOBYTE(wsaData.wVersion) != LOBYTE(versionRequested) || HIBYTE(wsaData.wVersion) != HIBYTE(versionRequested)) {
            WSACleanup();
-           CFLog(0, CFSTR("*** Could not initialize WinSock subsystem!!!"));
+           CFLog(kCFLogLevelEmergency, CFSTR("*** Could not initialize WinSock subsystem!!!"));
        }
     }
 #endif


### PR DESCRIPTION
This addresses #93 by replacing all level literals passed to `CFLog` with their equivalent mnemonics from _CFLogUtilities.h_.