### PR TITLE
Use prctl with PR_SET_NAME as a Fallback to Set the Private, Internal Thread Name on Linux

### DIFF
--- a/CFFileDescriptor.c
+++ b/CFFileDescriptor.c
@@ -457,6 +457,11 @@ CFRunLoopSourceRef CFFileDescriptorCreateRunLoopSource(CFAllocatorRef allocator,
 #include <sys/param.h>
 #endif
 
+#if DEPLOYMENT_TARGET_LINUX
+#include <linux/prctl.h>
+#include <sys/prctl.h>
+#endif
+
 /* Preprocessor Definitions */
 
 #if !defined(LOG_CFFILEDESCRIPTOR)
@@ -1038,6 +1043,8 @@ __CFFileDescriptorManager(void * arg) {
 #elif (PTHREAD_SETNAME_NP_ARGS == 1)
     pthread_setname_np("com.apple.CFFileDescriptor.private");
 #endif // (PTHREAD_SETNAME_NP_ARGS == 2)
+#elif DEPLOYMENT_TARGET_LINUX
+    prctl(PR_SET_NAME, "CFFileDescriptor", 0, 0, 0);
 #endif // HAVE_PTHREAD_SETNAME_NP
 
     if (objc_collectingEnabled()) {

--- a/CFSocket.c
+++ b/CFSocket.c
@@ -971,7 +971,9 @@ Boolean __CFSocketGetBytesAvailable(CFSocketRef s, CFIndex* ctBytesAvailable) {
 #elif DEPLOYMENT_TARGET_LINUX
 #include <fcntl.h>
 #include <linux/ioctl.h>
+#include <linux/prctl.h>
 #include <sys/param.h>
+#include <sys/prctl.h>
 #include <asm/ioctls.h>
 #include <netdb.h>
 #include <netinet/in.h>
@@ -1955,6 +1957,8 @@ static void __CFSocketManager(void * arg)
 #elif (PTHREAD_SETNAME_NP_ARGS == 1)
     pthread_setname_np("com.apple.CFSocket.private");
 #endif // (PTHREAD_SETNAME_NP_ARGS == 2)
+#elif DEPLOYMENT_TARGET_LINUX
+    prctl(PR_SET_NAME, "CFSocket", 0, 0, 0);
 #endif // HAVE_PTHREAD_SETNAME_NP
     if (objc_collectingEnabled()) objc_registerThreadWithCollector();
     SInt32 nrfds, maxnrfds, fdentries = 1;


### PR DESCRIPTION
This addresses #102 by using `prctl` with `PR_SET_NAME` as a fallback to set the private, internal thread name on Linux if `pthread_setname_np` is unavailable.