### PR TITLE
Prefer the Internal Portability '__CFIsCurrentProcessTainted' Function

### DIFF
--- a/CFInternal.h
+++ b/CFInternal.h
@@ -794,6 +794,8 @@ struct __objcFastEnumerationStateEquivalent {
     unsigned long extra[5];
 };
 
+__private_extern__ Boolean __CFIsCurrentProcessTainted(void);
+
 CF_EXTERN_C_END
 
 #endif /* ! __COREFOUNDATION_CFINTERNAL__ */

--- a/CFPlatform.c
+++ b/CFPlatform.c
@@ -264,7 +264,7 @@ static uint32_t __CFUID = -1;
 
 static CFURLRef _CFCopyHomeDirURLForUser(struct passwd *upwd) { // __CFPlatformCacheLock must be locked on entry and will be on exit
     CFURLRef home = NULL;
-    if (!issetugid()) {
+    if (!__CFIsCurrentProcessTainted()) {
 	const char *path = __CFgetenv("CFFIXED_USER_HOME");
 	if (path) {
 	    home = CFURLCreateFromFileSystemRepresentation(kCFAllocatorSystemDefault, (uint8_t *)path, strlen(path), true);

--- a/CFUtilities.c
+++ b/CFUtilities.c
@@ -389,7 +389,7 @@ __private_extern__ void *__CFLookupCoreServicesInternalFunction(const char *name
 #endif
 
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_LINUX
-static Boolean
+__private_extern__ Boolean
 __CFIsCurrentProcessTainted(void) {
 	Boolean ret = true;
 #if DEPLOYMENT_TARGET_MACOSX
@@ -402,6 +402,8 @@ __CFIsCurrentProcessTainted(void) {
 # else
 #  warning "Linux portability issue!"
 # endif /* HAVE_GETAUXVAL */
+#elif DEPLOYMENT_TARGET_WINDOWS
+    ret = false;
 #else
 # warning "Platform portability issue!"
 #endif
@@ -573,8 +575,8 @@ typedef void (*CFLogFunc)(int32_t lev, const char *message, size_t length, char 
 
 static Boolean also_do_stderr() {
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
-    if (!issetugid() && __CFgetenv("CFLOG_FORCE_STDERR")) {
-	return true;
+    if (!__CFIsCurrentProcessTainted() && __CFgetenv("CFLOG_FORCE_STDERR")) {
+	    return true;
     }
     struct stat sb;
     int ret = fstat(STDERR_FILENO, &sb);

--- a/CoreFoundation_Prefix.h
+++ b/CoreFoundation_Prefix.h
@@ -143,8 +143,6 @@ typedef int		boolean_t;
 #define strlcpy(a,b,c) strncpy(a,b,c)
 #endif
 
-#define issetugid() 0
-    
 // Implemented in CFPlatform.c 
 bool OSAtomicCompareAndSwapPtr(void *oldp, void *newp, void *volatile *dst);
 bool OSAtomicCompareAndSwapLong(long oldl, long newl, long volatile *dst);
@@ -300,8 +298,6 @@ CF_INLINE size_t malloc_size(void *memblock) {
 #define strlcpy(a,b,c) strncpy(a,b,c)
     
 #define sleep(x) Sleep(1000*x)
-
-#define issetugid() 0
 
 // CF exports these useful atomic operation functions on Windows
 CF_EXPORT bool OSAtomicCompareAndSwapPtr(void *oldp, void *newp, void *volatile *dst);


### PR DESCRIPTION
This addresses #106 by using the internal portability `__CFIsCurrentProcessTainted` function in lieu of the non-portable `issetugid`, eliminating conditional compilation around uses of `issetugid`.